### PR TITLE
Fix base URL and credential testing bugs

### DIFF
--- a/credentials/BrowserUseApi.credentials.ts
+++ b/credentials/BrowserUseApi.credentials.ts
@@ -41,7 +41,7 @@ export class BrowserUseApi implements ICredentialType {
 	test: ICredentialTestRequest = {
 		request: {
 			baseURL: '={{$credentials.baseUrl}}',
-			url: '/ping',
+			url: '/tasks',
 			method: 'GET',
 		},
 	};

--- a/nodes/BrowserUse/BrowserUse.node.ts
+++ b/nodes/BrowserUse/BrowserUse.node.ts
@@ -806,9 +806,10 @@ async function makeApiCall(
 	endpoint: string,
 	body?: any,
 ): Promise<any> {
+	const credentials = await this.getCredentials('browserUseApi');
 	const options: any = {
 		method,
-		baseURL: '={{$credentials.baseUrl}}',
+		baseURL: credentials.baseUrl as string,
 		url: endpoint,
 		headers: {
 			'Content-Type': 'application/json',


### PR DESCRIPTION
This fixes https://github.com/browser-use/n8n-nodes-browser-use/issues/1 and the following runtime error: "An unexpected issue occurred: Invalid URL. Please try again or contact support if the issue persists."

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes credential validation and base URL handling so API calls use the correct baseUrl and the test request succeeds. This removes the "Invalid URL" runtime error.

- **Bug Fixes**
  - Credential test now hits /tasks (replaces /ping) to match the API.
  - Base URL is read via this.getCredentials('browserUseApi') and used in requests.

<sup>Written for commit d3dc3d64c3fa57023841fce57cf7af80927dad5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

