### PR TITLE
Add missing API options for task execution

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm view:*)",
+      "WebFetch(domain:docs.cloud.browser-use.com)",
+      "Bash(pnpm build:*)"
+    ]
+  }
+}

--- a/nodes/BrowserUse/BrowserUse.node.ts
+++ b/nodes/BrowserUse/BrowserUse.node.ts
@@ -7,6 +7,21 @@ import {
 	NodeOperationError,
 } from 'n8n-workflow';
 
+const SUPPORTED_MODELS = [
+	{ name: 'Browser Use 2.0 (Default)', value: 'browser-use-2.0' },
+	{ name: 'Browser Use LLM', value: 'browser-use-llm' },
+	{ name: 'Claude Opus 4.5', value: 'claude-opus-4-5-20251101' },
+	{ name: 'Claude Sonnet 4.5', value: 'claude-sonnet-4-5-20250929' },
+	{ name: 'Claude Sonnet 4.6', value: 'claude-sonnet-4-6' },
+	{ name: 'Gemini 3 Flash Preview', value: 'gemini-3-flash-preview' },
+	{ name: 'Gemini 3 Pro Preview', value: 'gemini-3-pro-preview' },
+	{ name: 'Gemini Flash Latest', value: 'gemini-flash-latest' },
+	{ name: 'Gemini Flash Lite Latest', value: 'gemini-flash-lite-latest' },
+	{ name: 'GPT-4.1', value: 'gpt-4.1' },
+	{ name: 'GPT-4.1 Mini', value: 'gpt-4.1-mini' },
+	{ name: 'O3', value: 'o3' },
+] as const;
+
 export class BrowserUse implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Browser Use',
@@ -271,52 +286,7 @@ export class BrowserUse implements INodeType {
 						displayName: 'AI Model',
 						name: 'llm',
 						type: 'options',
-						options: [
-							{
-								name: 'Browser Use 2.0 (Default)',
-								value: 'browser-use-2.0',
-							},
-							{
-								name: 'Browser Use LLM',
-								value: 'browser-use-llm',
-							},
-							{
-								name: 'Claude Opus 4.5',
-								value: 'claude-opus-4-5-20251101',
-							},
-							{
-								name: 'Claude Sonnet 4.5',
-								value: 'claude-sonnet-4-5-20250929',
-							},
-							{
-								name: 'Gemini 3 Flash Preview',
-								value: 'gemini-3-flash-preview',
-							},
-							{
-								name: 'Gemini 3 Pro Preview',
-								value: 'gemini-3-pro-preview',
-							},
-							{
-								name: 'Gemini Flash Latest',
-								value: 'gemini-flash-latest',
-							},
-							{
-								name: 'Gemini Flash Lite Latest',
-								value: 'gemini-flash-lite-latest',
-							},
-							{
-								name: 'GPT-4.1',
-								value: 'gpt-4.1',
-							},
-							{
-								name: 'GPT-4.1 Mini',
-								value: 'gpt-4.1-mini',
-							},
-							{
-								name: 'O3',
-								value: 'o3',
-							},
-						],
+						options: [...SUPPORTED_MODELS],
 						default: 'browser-use-2.0',
 						description: 'The AI model to use for executing the task',
 					},
@@ -360,52 +330,7 @@ export class BrowserUse implements INodeType {
 						displayName: 'Judge LLM',
 						name: 'judgeLlm',
 						type: 'options',
-						options: [
-							{
-								name: 'Browser Use 2.0 (Default)',
-								value: 'browser-use-2.0',
-							},
-							{
-								name: 'Browser Use LLM',
-								value: 'browser-use-llm',
-							},
-							{
-								name: 'Claude Opus 4.5',
-								value: 'claude-opus-4-5-20251101',
-							},
-							{
-								name: 'Claude Sonnet 4.5',
-								value: 'claude-sonnet-4-5-20250929',
-							},
-							{
-								name: 'Gemini 3 Flash Preview',
-								value: 'gemini-3-flash-preview',
-							},
-							{
-								name: 'Gemini 3 Pro Preview',
-								value: 'gemini-3-pro-preview',
-							},
-							{
-								name: 'Gemini Flash Latest',
-								value: 'gemini-flash-latest',
-							},
-							{
-								name: 'Gemini Flash Lite Latest',
-								value: 'gemini-flash-lite-latest',
-							},
-							{
-								name: 'GPT-4.1',
-								value: 'gpt-4.1',
-							},
-							{
-								name: 'GPT-4.1 Mini',
-								value: 'gpt-4.1-mini',
-							},
-							{
-								name: 'O3',
-								value: 'o3',
-							},
-						],
+						options: [...SUPPORTED_MODELS],
 						default: 'browser-use-2.0',
 						description: 'The AI model to use for judging results',
 					},


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added missing task execution options to the BrowserUse node and wired them to the API for better control over browsing, sessions, judging, and performance. Also added safe JSON parsing, centralized model options, and clearer API error messages.

- **New Features**
  - Advanced controls: allowedDomains, sessionId, opVaultId, systemPromptExtension, metadata, secrets.
  - Execution toggles: flashMode, highlightElements, thinking, vision (auto/enabled/disabled), maxSteps.
  - Judging: judge, judgeGroundTruth, judgeLlm with shared model choices.

- **Bug Fixes**
  - Parse JSON inputs (metadata, secrets, allowedDomains) with safe fallback.
  - Send optional fields only when set; always include metadata source.
  - Centralized model list to avoid duplication and keep llm/judgeLlm options in sync.
  - Clearer API errors for 400/401/404/422 with validation details.

<sup>Written for commit b3130ce1c4688082019533bb9312bddc60c606a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

