### PR TITLE
Update api keygen docs

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm view:*)",
+      "WebFetch(domain:docs.cloud.browser-use.com)",
+      "Bash(pnpm build:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 package-lock.json
+.claude/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,7 @@
 const { src, dest } = require('gulp');
 
 function buildIcons() {
-	return src('nodes/**/*.svg').pipe(dest('dist/nodes'));
+	return src(['nodes/**/*.svg', 'nodes/**/*.node.json']).pipe(dest('dist/nodes'));
 }
 
 exports['build:icons'] = buildIcons;

--- a/nodes/BrowserUse/BrowserUse.node.json
+++ b/nodes/BrowserUse/BrowserUse.node.json
@@ -1,0 +1,18 @@
+{
+	"node": "n8n-nodes-browser-use-cloud.browserUse",
+	"nodeVersion": "1.0",
+	"codexVersion": "1.0",
+	"categories": ["Productivity"],
+	"resources": {
+		"credentialDocumentation": [
+			{
+				"url": "https://cloud.browser-use.com"
+			}
+		],
+		"primaryDocumentation": [
+			{
+				"url": "https://docs.cloud.browser-use.com"
+			}
+		]
+	}
+}

--- a/nodes/BrowserUse/BrowserUse.node.ts
+++ b/nodes/BrowserUse/BrowserUse.node.ts
@@ -445,26 +445,6 @@ export class BrowserUse implements INodeType {
 					},
 				],
 			},
-			{
-				displayName:
-					'Need an API key? Sign up at <a href="https://cloud.browser-use.com" target="_blank">cloud.browser-use.com</a>',
-				name: 'signupNotice',
-				type: 'notice',
-				default: '',
-				typeOptions: {
-					theme: 'success',
-				},
-			},
-			{
-				displayName:
-					'Documentation: <a href="https://docs.cloud.browser-use.com" target="_blank">docs.cloud.browser-use.com</a>',
-				name: 'docsNotice',
-				type: 'notice',
-				default: '',
-				typeOptions: {
-					theme: 'info',
-				},
-			},
 		],
 	};
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "n8n-nodes-browser-use-cloud",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"description": "n8n node for Browser Use Cloud API - Automate web tasks with AI agents",
 	"keywords": [
 		"n8n-community-node-package",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched BrowserUse node docs and API key info to codex metadata and updated the build to ship it. Removed inline notices, making the UI cleaner.

- **Refactors**
  - Added BrowserUse.node.json with primary docs and credential (API key) links.
  - Updated gulpfile to copy .node.json into dist.
  - Removed inline signup/docs notices from BrowserUse.node.ts.
  - Bumped package to 1.0.8 and ignored .claude/ in .gitignore.

<sup>Written for commit fb3a6473e6b36fcaa72a58ca80e28226a691b9c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

