### PR TITLE
Use Node 22 for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Update the npm publish workflow from Node 20 to Node 22 because isolated-vm@6.1.2 requires Node >=22 during install

## Validation
- Publish workflow failure was during pnpm install on Node 20 before lint/build/publish
- This aligns the publish workflow runtime with the dependency engine requirement

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the npm publish workflow to run on Node 22 to meet `isolated-vm@6.1.2`’s engine requirement (>=22). This fixes install failures on Node 20 in the publish job.

<sup>Written for commit ebf6fa9bcb918b875bd888eb8dd529765130b09c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

