### PR TITLE
Use npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,5 +34,3 @@ jobs:
 
       - name: Publish
         run: pnpm publish --no-git-checks --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove NODE_AUTH_TOKEN from the npm publish step so npm uses GitHub Actions OIDC trusted publishing
- Keep id-token: write and --provenance for verified n8n community node publishing

## Validation
- Workflow-only change; previous publish run passed install, lint, and build after Node 22 update

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the publish workflow to `npm` Trusted Publishing via GitHub Actions OIDC by removing `NODE_AUTH_TOKEN`, reducing secret usage and improving security. `id-token: write` and `--provenance` remain to support verified `n8n` community node publishing.

<sup>Written for commit 2372ae8b3e9a75b09ea4e865a308c9189127a9fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

