### PR TITLE
Publish with npm OIDC auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
+          node-version: 24
+          package-manager-cache: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -33,4 +33,6 @@ jobs:
         run: pnpm build
 
       - name: Publish
-        run: pnpm publish --no-git-checks --access public --provenance
+        run: |
+          unset NODE_AUTH_TOKEN
+          npm publish --access public --provenance


### PR DESCRIPTION
## Summary
- Use Node 24 for the publish workflow, matching npm trusted publishing guidance
- Publish with npm directly instead of pnpm publish
- Unset NODE_AUTH_TOKEN before publishing so npm uses GitHub Actions OIDC trusted publishing

## Validation
- Workflow-only change intended to address the publish step still using token auth

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the publish workflow to GitHub Actions OIDC trusted publishing by using Node 24 and `npm publish` with provenance. Removes token-based auth to ensure trusted, traceable releases.

- **Bug Fixes**
  - Use Node 24 to match npm trusted publishing guidance.
  - Replace `pnpm publish` with `npm publish --access public --provenance`.
  - Unset `NODE_AUTH_TOKEN` so `npm` uses OIDC. Disable package-manager cache in `setup-node`.

<sup>Written for commit b561291f6f41b2354d5912bed47906b3daca1376. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

