### PR TITLE
Remove unsupported setup-node input

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          package-manager-cache: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Remove the unsupported package-manager-cache input from actions/setup-node@v4
- Keeps the successful Node 24 / OIDC trusted publishing setup unchanged

## Validation
- Workflow-only cleanup after v1.1.0 successfully published with provenance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unsupported `package-manager-cache` input from the publish workflow’s `actions/setup-node@v4` step to clean up the config. Node 24 and OIDC trusted publishing remain unchanged.

<sup>Written for commit d3c0315be10e4a6a98fa4e649cc6f2bca9a3ba06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

