### PR TITLE
Remove restricted setTimeout usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.1
+
+### Fixed
+
+- Removed direct `setTimeout` usage from the Browser Use v3 polling helper to satisfy n8n community package security checks.
+
 ## 1.1.0
 
 ### Added

--- a/nodes/BrowserUseV3/BrowserUseV3.node.ts
+++ b/nodes/BrowserUseV3/BrowserUseV3.node.ts
@@ -7,6 +7,7 @@ import {
 	JsonObject,
 	NodeApiError,
 	NodeOperationError,
+	sleep,
 } from 'n8n-workflow';
 
 const TERMINAL_SESSION_STATUSES = ['stopped', 'timed_out', 'error'];
@@ -1283,10 +1284,6 @@ function extractErrorMessage(error: unknown, responseData: any): string {
 
 function getVersionedBaseUrl(baseUrl: string, version: 'v2' | 'v3'): string {
 	return baseUrl.replace(/\/api\/v[23]\/?$/, `/api/${version}`);
-}
-
-function sleep(milliseconds: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 function getSchemaTemplate(templateType: string): any {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "n8n-nodes-browser-use-cloud",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "n8n node for Browser Use Cloud API v3 - agent sessions and cloud browsers",
 	"keywords": [
 		"n8n-community-node-package",


### PR DESCRIPTION
## Summary
- Replace the Browser Use v3 polling helper's direct setTimeout usage with n8n-workflow's sleep utility
- Bump package version to 1.1.1 for republishing
- Add a 1.1.1 changelog entry for the scanner fix

## Validation
- pnpm format
- pnpm lint
- pnpm build
- pnpm audit --audit-level moderate
- npm pack --dry-run
- Confirmed built dist output no longer contains setTimeout

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced direct `setTimeout` in the Browser Use v3 polling helper with `sleep` from `n8n-workflow` to satisfy n8n community package security checks. Bumps package to `1.1.1` and updates the changelog.

<sup>Written for commit 92801bf19a98169702fcafc6b269a9efd0a3df9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

