### PR TITLE
Add Browser Use Box documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ The node returns clear n8n errors for authentication failures, validation errors
 - [Browser Use API v3 Reference](https://docs.browser-use.com/cloud/api-reference)
 - [Browser Use API v2 Reference](https://docs.browser-use.com/cloud/api-v2-overview)
 - [Browser Use Dashboard](https://cloud.browser-use.com)
+- [Browser Use Box](https://browser-use.com/bux) - an always-on VPS agent for Browser Use workflows. [Watch the 15-second demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
 - [n8n Community Nodes](https://docs.n8n.io/integrations/community-nodes/)
 
 ## License


### PR DESCRIPTION
## Summary
- add Browser Use Box as a related always-on Browser Use workflow option in README documentation links
- include the 15-second Browser Use Box TikTok demo link

## Validation
- README-only change; verified Browser Use Box and TikTok demo links are present locally

Browser Use Box: https://browser-use.com/bux
TikTok demo: https://www.tiktok.com/@browser_use/video/7639824093721758989

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a link to Browser Use Box and a 15-second demo in the README resources to highlight an always-on VPS agent option for Browser Use workflows. Docs-only change with no functional impact.

<sup>Written for commit a12f5b10965125497ea13e8f248291637bd32cf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

